### PR TITLE
fix: :bug: fixed: navigating beyond last and first shlok is not possible

### DIFF
--- a/holyglimps/src/pages/chapter/[...verse].tsx
+++ b/holyglimps/src/pages/chapter/[...verse].tsx
@@ -16,12 +16,16 @@ const Verse = () => {
   const [data, setData] = useState({});
 
   const handleNext = () => {
-    const nextVerseNumber = parseInt(verseNumber) + 1;
-    router.push(`/chapter/${chapterNumber}/verse/${nextVerseNumber}`);
+    if(verseNumber != `${verseCount}`){
+      const nextVerseNumber = parseInt(verseNumber) + 1;
+      router.push(`/chapter/${chapterNumber}/verse/${nextVerseNumber}`);
+    }
   };
   const handlePrev = () => {
-    const nextVerseNumber = parseInt(verseNumber) - 1;
-    router.push(`/chapter/${chapterNumber}/verse/${nextVerseNumber}`);
+    if(verseNumber != '1') {
+      const nextVerseNumber = parseInt(verseNumber) - 1;
+      router.push(`/chapter/${chapterNumber}/verse/${nextVerseNumber}`);
+    }
   };
   const handleGoBack = () => {
     router.push("/chapter/1"); // This will take the user back to the previous page


### PR DESCRIPTION
earlier on clicking previous and next buttons on read-shloka page the shloka count goes negative and beyound defined shloka number. Now it is fixed.